### PR TITLE
Graphite support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [Alertra](https://alertra.com) repeatedly pings urls from around the globe and records stats about the
 responses (timing, bytes, location, ...). This tool uses alertra's API to pull
 down check data for all devices (urls its configured to ping) and expose that
-as prometheus metrics.
+as prometheus and graphite metrics.
 
-Specifically, this exposes three gauge metrics:
+Specifically, this exposes three prometheus gauge metrics:
    
     # Reported once per device and location and component (DNS, TTFB, ...) such that
     #    sum by (device, location)(alertra_check_time) of these should match the
@@ -21,13 +21,22 @@ Specifically, this exposes three gauge metrics:
     HELP alertra_check_response_bytes Number of bytes in the response
     TYPE alertra_check_response_bytes gauge
 
+The same information is reported to graphite if configured as three gauge metrics:
+
+    alertra.check_time
+    alertra.check_total_time
+    alertra.check_response_bytes
+
 ### Config
 
 * env: `ALERTRA_API_KEY`
 * env: `PORT` (default 13964) tcp port on which to listen for http requests
 * env: `METRIC_CACHE_TTL` (default 600) Cache lifetime for alertra data
     * After this many seconds have passed since the data was fetch, it'll be fetched again on the next request
-
+* env: `GRAPHITE_HOST` (default null) hostname of graphite server
+    * If not null, this server will also report these stats to graphite
+* env: `GRAPHITE_PORT` (default 2003) port number of graphite server
+* env: `GRAPHITE_INTERVAL_S` (default 10s) How often in seconds to report these metrics to graphite
 
 ### Usage
 

--- a/app.ts
+++ b/app.ts
@@ -1,8 +1,10 @@
 import { Alertra, CheckRecord } from './lib/alertra/alertra.js';
 import { ChecksByDeviceAndLocation, getChecksByDeviceAndLocationLoader } from './lib/alertra/alertra-checks.js';
 import * as http from "http";
+import * as net from "net";
 import { getPromtheusResponseForMetrics } from './lib/prometheus.js';
 import { getMetricsFromDevices } from './lib/metrics.js';
+import { getGraphiteBodyForMetrics } from './lib/graphite.js';
 
 const httpPort = Number(process.env.PORT) || 13964;
 const cacheTTL = Number(process.env.METRIC_CACHE_TTL) || 10 * 60;
@@ -26,3 +28,26 @@ http.createServer(async (req, res) => {
 }).listen(httpPort);
 
 console.log("Listening for requests on port " + httpPort);
+
+const graphiteHost = String(process.env.GRAPHITE_HOST);
+if (graphiteHost) {
+  const graphitePort = Number(process.env.GRAPHITE_PORT) || 2003;
+  const graphiteInterval = Number(process.env.GRAPHITE_INTERVAL_S) || 60;
+  console.log(`Reporting metrics to Graphite at ${graphiteHost}:${graphitePort} every ${graphiteInterval} seconds`);
+  setInterval(async () => {
+    try {
+      const devices = await getChecksByDevice();
+      const metrics = getMetricsFromDevices(devices);
+      const graphiteSocket = net.createConnection(graphitePort, graphiteHost);
+      graphiteSocket.on("connect", () => {
+        graphiteSocket.end(getGraphiteBodyForMetrics(metrics));
+      });
+      graphiteSocket.on("error", (e: Error) => {
+        console.error(`Failed to connect or write graphite metrics to ${graphiteHost}:${graphitePort}: ${e.message}`);
+        graphiteSocket.destroy();
+      });
+    } catch (e) {
+      console.error(e);
+    }
+  }, graphiteInterval * 1000);
+}

--- a/lib/graphite.ts
+++ b/lib/graphite.ts
@@ -1,0 +1,31 @@
+import type { Labels, Metric } from "./metrics.js";
+
+export function getGraphiteBodyForMetrics(metrics: Metric[]): string {
+  const output: string[] = [];
+  const ts = Math.round(Date.now() / 1000);
+  metrics.forEach(({name, values}) => {
+    values.forEach(([labels, value]) => {
+      output.push(metric(name, labels, value, ts))
+    });
+  });
+  return output.join("\n");
+}
+
+function safeLabel(label: string) {
+  return label.replace(/[;!^= ]+/g, "_");
+}
+
+function safeLabelValue(value: string) {
+  return value.replace(/^~|[; ]+/g, "_");
+}
+
+function toLabelString(labels: Labels) {
+  return Object.entries(labels).map(
+    ([name, value]) => `${safeLabel(name)}=${safeLabelValue(value)}`
+  ).join(";");
+}
+
+function metric(name: string, labels: Labels, value: number, timestamp: number) {
+   const graphiteName = name.replace(/^alertra_/, "alertra.");
+   return `${graphiteName};${toLabelString(labels)} ${value} ${timestamp}`;
+}


### PR DESCRIPTION
Add support for writing the same metrics to graphite. Graphite now supports labels, so let's use those too.

Prometheus is better for real time alerting, while graphite is better for long term archival storage. So, let's support both (based on env vars)